### PR TITLE
ssl hive-interactive (llap) webui

### DIFF
--- a/conf/enable_configs2700.yaml
+++ b/conf/enable_configs2700.yaml
@@ -76,6 +76,11 @@ HIVE:
     hive.server2.use.SSL: true
     hive.server2.keystore.path: $keystore
     hive.server2.keystore.password: $keystorepassword
+    
+  - config_type: hive-interactive-site
+    hive.server2.webui.use.ssl=true
+    hive.server2.webui.keystore.path=$truststore
+    hive.server2.webui.keystore.password=$truststorepassword
 
 ZEPPELIN:
   - config_type: zeppelin-site


### PR DESCRIPTION
- it will inherit the keystore from normal hive, but the alert is hardcoded to use the truststore setting within hive-interactive-site